### PR TITLE
Implement crude space width determinator

### DIFF
--- a/lib/pdf/reader/page_text_receiver.rb
+++ b/lib/pdf/reader/page_text_receiver.rb
@@ -141,7 +141,8 @@ module PDF
           th = 1
           scaled_glyph_width = glyph_width * @state.font_size * th
           unless utf8_chars == SPACE
-            @characters << TextRun.new(newx, newy, scaled_glyph_width, @state.font_size, utf8_chars)
+            space_width = @state.current_font.glyph_width_in_text_space(32)
+            @characters << TextRun.new(newx, newy, scaled_glyph_width, @state.font_size, utf8_chars, space_width)
           end
           @state.process_glyph_displacement(glyph_width, 0, utf8_chars == SPACE)
         end


### PR DESCRIPTION
First of all, compute an approximate space width during decomposition of data into text runs, and second, apply some additional magic number logic during post-processing to improve detection of text runs which should be merged.

Presently, this arrangement was arrived at through a binary approach to find numbers and approaches that work as best as possible to get my work done with the hopes I'll return and further tune and test this against inputs outside of my current, and narrow, scope of work.